### PR TITLE
Delete the BIGENDIAN macro while calculating nwkid.

### DIFF
--- a/src/fwd/src/pkt_serv.c
+++ b/src/fwd/src/pkt_serv.c
@@ -407,11 +407,11 @@ static void thread_pkt_deal_up(void* arg) {
     serv_s* serv = serv_ct->serv;
     //pthread_t tid = pthread_self();
     
-	int i, j;					/*!> loop variables */
+    int i, j;                   /*!> loop variables */
 
     int fsize = 0;              /* FRMpayload size */
 
-	struct lgw_pkt_rx_s *p;	/*!> pointer on a RX packet */
+    struct lgw_pkt_rx_s *p;	/*!> pointer on a RX packet */
 
     enum jit_error_e jit_result = JIT_ERROR_OK;
     
@@ -500,7 +500,7 @@ static void thread_pkt_deal_up(void* arg) {
             continue;
 
         if (serv->filter.fport != NOFILTER || serv->filter.devaddr != NOFILTER || 
-			serv->filter.nwkid != NOFILTER || serv->filter.deveui != NOFILTER) {
+            serv->filter.nwkid != NOFILTER || serv->filter.deveui != NOFILTER) {
             if (pkt_basic_filter(serv, macmsg.FHDR.DevAddr, macmsg.FPort, macmsg.DevEUI)) {
                 lgw_log(LOG_DEBUG, "%s[%s-UP] Drop a packet has fport(%u) of %08X.\n", DEBUGMSG, serv->info.name, macmsg.FPort, macmsg.FHDR.DevAddr);
                 continue;
@@ -549,7 +549,7 @@ static void thread_pkt_deal_up(void* arg) {
 
             if (GW.cfg.mac_decode) {
                 uint32_t fcnt, mic;
-				bool fcnt_valid = false;
+                bool fcnt_valid = false;
                 lgw_memcpy(payload_encrypt, p->payload + 9 + macmsg.FHDR.FCtrl.Bits.FOptsLen, fsize);
                 for (j = 0; j < GW.cfg.fcnt_gap; j++) {   
                     fcnt = macmsg.FHDR.FCnt | (j * 0x10000);

--- a/src/fwd/src/service.c
+++ b/src/fwd/src/service.c
@@ -120,11 +120,9 @@ bool pkt_basic_filter(serv_s* serv, const uint32_t addr, const uint8_t fport, co
 
     snprintf(addr_key, sizeof(addr_key), "%s/devaddr/%08X", serv->info.name, addr);
     snprintf(fport_key, sizeof(fport_key), "%s/fport/%u", serv->info.name, fport);
-#ifdef BIGENDIAN
-        nwkid = addr & 0x7F;
-#else
-        nwkid = (addr >> 25) & 0x7F;   /* Devaddr Format:  31..25(NwkID)  24..0(NwkAddr) */
-#endif
+
+    nwkid = (addr >> 25) & 0x7F;   /* Devaddr Format:  31..25(NwkID)  24..0(NwkAddr) */
+
     snprintf(nwkid_key, sizeof(nwkid_key), "%s/nwkid/%02X", serv->info.name, nwkid);
     snprintf(deveui_key, sizeof(deveui_key), "%s/deveui/%s", serv->info.name, deveui);
 

--- a/src/station/src/s2e.c
+++ b/src/station/src/s2e.c
@@ -59,11 +59,9 @@ static bool basic_station_filter(StationFilter_t *pBSFilter, LoraMessage_t *Lora
 
     snprintf(addr_key, sizeof(addr_key), "%s/devaddr/%08X", pBSFilter->server_name, LoraMessage->devAddr);
     snprintf(fport_key, sizeof(fport_key), "%s/fport/%u", pBSFilter->server_name, LoraMessage->fPort);
-#ifdef BIGENDIAN
-    nwkid = (LoraMessage->devAddr) & 0x7F;
-#else
+
     nwkid = (LoraMessage->devAddr >> 25) & 0x7F;   /* Devaddr Format:  31..25(NwkID)  24..0(NwkAddr) */
-#endif
+
     snprintf(nwkid_key, sizeof(nwkid_key), "%s/nwkid/%02X", pBSFilter->server_name, nwkid);
 
     char deveui_str[17]={0};


### PR DESCRIPTION
The BIGENDIAN macro may cause the different compiling results while calculating nwkid on H3 and Openwrt,so,delete it.